### PR TITLE
Fixed warning errors

### DIFF
--- a/modules/widget.php
+++ b/modules/widget.php
@@ -2,11 +2,13 @@
 
 add_action(
 	'widgets_init',
-	create_function( '', 'return register_widget( "Simple_Related_Posts_Widget" );' )
+	function() {
+		return register_widget( "Simple_Related_Posts_Widget" );
+	}
 );
- 
+
 class Simple_Related_Posts_Widget extends WP_Widget {
- 
+
 function __construct() {
 	$widget_ops  = array( 'description' => __( 'Displays related posts.', SIRP_DOMAIN ) );
 	$control_ops = array();
@@ -17,7 +19,7 @@ function __construct() {
 		$control_ops
 	);
 }
- 
+
 public function form( $par ) {
 
 	// Title
@@ -47,11 +49,11 @@ public function form( $par ) {
 	</p>
 	<?php
 }
- 
+
 public function update( $new_instance, $old_instance ) {
 	return $new_instance;
 }
- 
+
 public function widget( $args, $par ) {
 
 	$if_show_widget = apply_filters( 'sirp_if_show_widget', is_single() );


### PR DESCRIPTION
Fixed the following errors with PHP7.

```
[19-Feb-2019 03:44:12 UTC] PHP Deprecated:  Function create_function() is deprecated in /var/www/vhosts/i-05f74104b040a6403/wp-content/plugins/wp-simple-related-posts/modules/widget.php on line 5
[19-Feb-2019 03:44:39 UTC] PHP Deprecated:  Function create_function() is deprecated in /var/www/vhosts/i-05f74104b040a6403/wp-content/plugins/wp-simple-related-posts/modules/widget.php on line 5
```