### PR TITLE
投稿に保存される関連記事 ID を常に配列で取得するよう変更

### DIFF
--- a/modules/base.php
+++ b/modules/base.php
@@ -65,9 +65,15 @@ class Simple_Related_Posts_Base {
     	if ( empty( $post_id ) )
 			return false;
 
-		$posts = get_post_meta( $post_id, 'simple_related_posts', false );
+		$posts = get_post_meta( $post_id, 'simple_related_posts', true );
+
+		// If for some reason meta_value returns as serialized data, try maybe_unsirialize again.
+		if ( ! is_array( $posts ) ) {
+			$posts = maybe_serialize( $posts );
+		}
 		
-		if ( !$posts && ! is_array( $posts ) )
+		// `$posts` is maybe_unserialized so it's definitely an array. Therefore, `! $posts` is equivalent to `empty( $posts )`.
+		if ( ! $posts && ! is_array( $posts ) )
 			return false;
 		
 		$posts_ids = array();

--- a/modules/base.php
+++ b/modules/base.php
@@ -65,13 +65,13 @@ class Simple_Related_Posts_Base {
     	if ( empty( $post_id ) )
 			return false;
 
-		$posts = get_post_meta( $post_id, 'simple_related_posts', true );
+		$posts = get_post_meta( $post_id, 'simple_related_posts', false );
 		
-		if ( !$posts )
+		if ( !$posts && ! is_array( $posts ) )
 			return false;
 		
 		$posts_ids = array();
-		foreach ( $posts as $id ) {
+		foreach ( (array) $posts as $id ) {
 			$my_post = get_post($id);
 			if ( $my_post->post_status === 'publish' && empty($my_post->post_password) ) {
 				$posts_ids[]['ID'] = $id;

--- a/modules/base.php
+++ b/modules/base.php
@@ -73,7 +73,7 @@ class Simple_Related_Posts_Base {
 		}
 		
 		// `$posts` is maybe_unserialized so it's definitely an array. Therefore, `! $posts` is equivalent to `empty( $posts )`.
-		if ( ! $posts && ! is_array( $posts ) )
+		if ( empty( $posts ) || ! is_array( $posts ) )
 			return false;
 		
 		$posts_ids = array();

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: horike,amimotoami,webnist,wokamoto,gatespace,mt8biz
 Tags:  related posts,related
 Requires at least: 3.8.1
-Tested up to: 5.8
-Stable tag: 1.5.9
+Tested up to: 6.3.1
+Stable tag: 1.6.1
 
 Related Posts plugin. It's flexible and fast and simple.
 

--- a/readme.txt
+++ b/readme.txt
@@ -85,3 +85,5 @@ You can use JSON REST API Endpoint. Require plugin [JSON REST API](https://wordp
 * Support for Block Editor
 = 1.6.0 =
 * Added support for manual addition when posts are in draft status.
+= 1.6.1 =
+* Changed to always get post ID as an array.

--- a/simple-related-posts.php
+++ b/simple-related-posts.php
@@ -4,7 +4,7 @@ Plugin Name: WP Simple Related Posts
 Plugin URI: https://github.com/megumiteam/wp-simple-related-posts
 Description: Display Related Posts. Very Simple.
 Author: digitalcube
-Version: 1.6.0
+Version: 1.6.1
 Author URI: https://github.com/megumiteam/wp-simple-related-posts
 Text Domain: simple-related-posts
 Domain Path: /languages/


### PR DESCRIPTION
# 修正
modules/base.php
- meta_value が配列ではない時、再度 maybe_unsirialize するよう変更
- 配列で取得できない場合処理を中止するよう変更
- foreach ループで $posts を配列にキャストするよう変更
- $posts が空の時または $posts が廃列ではない時処理を終了するよう変更
https://github.com/megumiteam/wp-simple-related-posts/pull/18/files#diff-b991cdaa46278c585a576ae3d09fb8637caf9153535ae8aa649ea918a89cc826R76

readme.txt
- Tested up to を 6.3.1 に変更
- Stable tag を 1.6.1 に変更

simple-related-posts.php
-  プラグインのバージョンを変更 (1.6.0 → 1.6.1)